### PR TITLE
der er problemer med posterdown

### DIFF
--- a/poster/poster_dk.omdøbtilrmd
+++ b/poster/poster_dk.omdøbtilrmd
@@ -38,6 +38,11 @@ knit: (function(inputFile, encoding) { rmarkdown::render(inputFile, encoding = e
 
 ---
 
+Denne side fører, af årsager jeg ikke helt forstår, til fejl på github.
+Formentlig fordi den prøver at installere posterdownpakken. Derfor er denne side
+omdøbt til poster_dk.omdøbtilrmd. Når siden skal genereres - omdøb den og gør det 
+lokalt.
+
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = FALSE,
                       warning = FALSE,


### PR DESCRIPTION
Som af årsager der ikke står helt klart, giver problemer når ci/cd flowet kører på github. Poster rmd'en er derfor omdøbt til noget som github actions forhåbentlig ikke finder